### PR TITLE
initial simple github mcp example

### DIFF
--- a/examples/github-mcp/README.md
+++ b/examples/github-mcp/README.md
@@ -1,0 +1,14 @@
+This is a simple example of an MCP tool call to the GitHub remote MCP
+server. To run the example there are several environment variables
+that need to be set:
+
+* GITHUB_TOKEN should be set to a personal access token (only requires read access)
+
+* OPENAI_BASE_URL should be set to point at the responses API
+  server. In the case of a local LlamaStack instance that would be
+  e.g. <http://localhost:8321/v1/openai/v1>
+
+* OPENAI_API_KEY should be set to your OpenAI API key if using an
+  OpenAI provided model (which it does by default)
+
+Run with: `go run github-mcp-example.go`.

--- a/examples/github-mcp/github-mcp-example.go
+++ b/examples/github-mcp/github-mcp-example.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+)
+
+func main() {
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if token == "" {
+		log.Fatalln("Please set GITHUB_TOKEN in env")
+	}
+	model := os.Getenv("INFERENCE_MODEL")
+	if model == "" {
+		model = openai.ChatModelGPT4o
+	}
+	log.Printf("Using model %s", model)
+	client := openai.NewClient()
+	ctx := context.TODO()
+	params := responses.ResponseNewParams{
+		Model:           model,
+		Tools:           []responses.ToolUnionParam{
+			{
+				OfMcp: &responses.ToolMcpParam{
+					ServerLabel: "github",
+					ServerURL:   "https://api.githubcopilot.com/mcp/x/repos/readonly",
+					Headers:     map[string]string{
+						"Authorization": "Bearer " + token,
+					},
+				},
+			},
+		},
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Using the tool provided, summarize the five most recent commits on main for the llama-stack repo owned by llamastack?"),
+		},
+	}
+
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	log.Println(resp.OutputText())
+}

--- a/examples/github-mcp/go.mod
+++ b/examples/github-mcp/go.mod
@@ -1,0 +1,12 @@
+module github.com/opendatahub-io/agents/examples/github-mcp
+
+go 1.24
+
+require github.com/openai/openai-go v1.12.0
+
+require (
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+)

--- a/examples/github-mcp/go.sum
+++ b/examples/github-mcp/go.sum
@@ -1,0 +1,12 @@
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a runnable example that invokes a GitHub-backed MCP tool to summarize recent repository commits; model selection is configurable via environment variables.

- Documentation
  - Added a README with setup steps, required environment variables (GitHub token, API base URL, API key), and the command to run the example.

- Chores
  - Added module metadata and dependencies to enable building and running the example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->