### PR TITLE
Initial example using a servicenow mcp server

### DIFF
--- a/examples/servicenow-mcp/README.md
+++ b/examples/servicenow-mcp/README.md
@@ -1,0 +1,49 @@
+This is a simple example of making an MCP tool call against the
+servicenow MCP server from
+https://github.com/echelon-ai-labs/servicenow-mcp in SSE mode. Note
+that this server does not support authorisation. It uses credentials
+set in its environment (as described in installation guide at that
+link) to access the servicenow instance.
+
+To run the example there are several environment variables
+that need to be set:
+
+* OPENAI_BASE_URL should be set to point at the responses API
+  server. In the case of a local LlamaStack instance that would be
+  e.g. <http://localhost:8321/v1/openai/v1>
+
+* OPENAI_API_KEY should be set to your OpenAI API key if using an
+  OpenAI provided model (which it does by default)
+
+* INFERENCE_MODEL (optional) can override the default model used by
+  the example program.
+
+To run:
+
+```
+go mod tidy
+go run servicenow-mcp-example.go
+```
+
+## Running the MCP server
+
+First you need to set up the following environment variables:
+
+```
+SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
+SERVICENOW_USERNAME=your-username
+SERVICENOW_PASSWORD=your-password
+SERVICENOW_AUTH_TYPE=basic
+```
+
+You can sign up with the servicenow developer program and request a
+test instance to work with here: https://developer.servicenow.com/
+
+Then, after cloning the mcp server repo, from the base directory run:
+
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+servicenow-mcp-sse --host=127.0.0.1 --port=8000
+```

--- a/examples/servicenow-mcp/go.mod
+++ b/examples/servicenow-mcp/go.mod
@@ -1,0 +1,12 @@
+module github.com/opendatahub-io/agents/examples/servicenow-mcp
+
+go 1.24
+
+require github.com/openai/openai-go v1.12.0
+
+require (
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+)

--- a/examples/servicenow-mcp/go.sum
+++ b/examples/servicenow-mcp/go.sum
@@ -1,0 +1,12 @@
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=

--- a/examples/servicenow-mcp/servicenow-mcp-example.go
+++ b/examples/servicenow-mcp/servicenow-mcp-example.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+)
+
+func main() {
+	model := os.Getenv("INFERENCE_MODEL")
+	if model == "" {
+		model = openai.ChatModelGPT4o
+	}
+	log.Printf("Using model %s", model)
+	client := openai.NewClient()
+	ctx := context.TODO()
+	params := responses.ResponseNewParams{
+		Model:           model,
+		Tools:           []responses.ToolUnionParam{
+			{
+				OfMcp: &responses.ToolMcpParam{
+					ServerLabel: "servicenow",
+					ServerURL:   "http://127.0.0.1:8000/sse",
+					AllowedTools: responses.ToolMcpAllowedToolsUnionParam{
+						OfMcpAllowedTools: []string{
+							"list_incidents",
+						},
+					},
+				},
+			},
+		},
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Using the tool provided, summarize the five most recent incidents."),
+		},
+	}
+
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	log.Println(resp.OutputText())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Runnable Go example demonstrating interaction with a ServiceNow MCP server over SSE via the OpenAI client, including a sample request to list recent incidents.

- Documentation
  - Added README with setup and run instructions, required environment variables (e.g., OPENAI_BASE_URL, OPENAI_API_KEY), ServiceNow MCP server setup steps, and link to the external MCP repo.

- Chores
  - Added a new Go module and dependencies to support building and running the example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->