### PR TITLE
Initial example using MCP to create a google doc with model generated content

### DIFF
--- a/examples/gsuite-mcp/README.md
+++ b/examples/gsuite-mcp/README.md
@@ -1,0 +1,59 @@
+This is a simple example of making an MCP tool call against the Google
+Workspace MCP server from
+https://github.com/taylorwilsdon/google_workspace_mcp.
+
+Getting an appropriate bearer token for use with this MCP server is
+not trivial. The provided example implements a rudimentary flow to
+automatically obtain one under the account of the user running the
+example, once they have authenticated and granted permission. For this
+the following two environment variables need to be set to the details
+as configured in the Google Workspace project:
+
+* GOOGLE_OAUTH_CLIENT_ID
+* GOOGLE_OAUTH_CLIENT_SECRET
+
+Follow the instructions from the MCP servers README at
+https://github.com/taylorwilsdon/google_workspace_mcp?tab=readme-ov-file#configuration
+to setup a client.
+
+To run the example there are some other environment variables
+that need to be set:
+
+* OPENAI_BASE_URL should be set to point at the responses API
+  server. In the case of a local LlamaStack instance that would be
+  e.g. <http://localhost:8321/v1/openai/v1>
+
+* OPENAI_API_KEY should be set to your OpenAI API key if using an
+  OpenAI provided model (which it does by default)
+
+* INFERENCE_MODEL can be used to alter the model used
+
+To run:
+
+```
+go mod tidy
+go run google-doc-mcp-example.go
+```
+
+## Running the MCP server for this example
+
+To run the MCP server in a configuration that supports this example,
+the following environment variables need to be set:
+
+```
+OAUTHLIB_INSECURE_TRANSPORT=1
+USER_GOOGLE_EMAIL=<whatever email associated with the google client created>
+WORKSPACE_MCP_BASE_URI=http://localhost
+WORKSPACE_MCP_PORT=9876
+MCP_ENABLE_OAUTH21=true
+GOOGLE_OAUTH_CLIENT_ID=<client id as downloaded from google workspace console>
+GOOGLE_OAUTH_CLIENT_SECRET=<client secret as downloaded from google workspace console>
+```
+
+Then, after cloning the MCP server repo, in the base directory run:
+
+```
+uv run main.py --tools docs --transport streamable-http
+```
+
+

--- a/examples/gsuite-mcp/go.mod
+++ b/examples/gsuite-mcp/go.mod
@@ -1,0 +1,15 @@
+module github.com/opendatahub-io/agents/examples/gsuite-mcp
+
+go 1.24
+
+require (
+	github.com/openai/openai-go v1.12.0
+	golang.org/x/oauth2 v0.30.0
+)
+
+require (
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+)

--- a/examples/gsuite-mcp/google-doc-mcp-example.go
+++ b/examples/gsuite-mcp/google-doc-mcp-example.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"crypto/rand"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+)
+
+type AuthCodeReceiver struct{
+	server *httptest.Server
+	code   chan string
+	path   string
+	state  string
+}
+
+func newAuthCodeReceiver() *AuthCodeReceiver{
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		log.Fatalf("failed generating oauth state: %v", err)
+	}
+	state := base64.RawURLEncoding.EncodeToString(b)
+	return &AuthCodeReceiver{
+		code: make(chan string),
+		path: "/submit",
+		state: state,
+	}
+}
+
+func (o *AuthCodeReceiver) start() {
+	mux := http.NewServeMux()
+	mux.HandleFunc(o.path, func(w http.ResponseWriter, r *http.Request) {
+		params, _ := url.ParseQuery(r.URL.RawQuery)
+		if e := params.Get("error"); e != "" {
+			http.Error(w, "Authorization failed: "+e, http.StatusBadRequest)
+			return
+		}
+		if s := params.Get("state"); s == "" || s != o.state {
+			http.Error(w, "Invalid state", http.StatusBadRequest)
+			return
+		}
+		if code := params.Get("code"); code != "" {
+			o.code <- code
+			fmt.Fprint(w, "Return to example!")
+			return
+		}
+		http.Error(w, "Missing code", http.StatusBadRequest)
+	})	
+	o.server = httptest.NewServer(mux)
+}
+
+func (r *AuthCodeReceiver) url() string {
+	return r.server.URL + r.path
+}
+
+func (r *AuthCodeReceiver) getCode() string {
+	code := <-r.code
+	return code
+}
+
+func (r *AuthCodeReceiver) stop() {
+	r.server.Close()
+}
+
+func main() {
+	codeReceiver := newAuthCodeReceiver()
+	codeReceiver.start()
+	defer codeReceiver.stop()
+	clientId := strings.TrimSpace(os.Getenv("GOOGLE_OAUTH_CLIENT_ID"))
+	clientSecret := strings.TrimSpace(os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"))
+	ctx := context.Background()
+	conf := &oauth2.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		Scopes:       []string{
+			"https://www.googleapis.com/auth/documents",
+			"https://www.googleapis.com/auth/documents.readonly",
+			"https://www.googleapis.com/auth/userinfo.email",
+			"https://www.googleapis.com/auth/userinfo.profile",
+			"openid",
+		},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+			TokenURL: "https://oauth2.googleapis.com/token",
+		},
+		RedirectURL: codeReceiver.url(),
+	}
+
+	verifier := oauth2.GenerateVerifier()
+	authURL := conf.AuthCodeURL(
+		codeReceiver.state,
+		oauth2.AccessTypeOffline,
+		oauth2.S256ChallengeOption(verifier),
+		oauth2.SetAuthURLParam("prompt", "consent"),
+	)
+	fmt.Printf("Visit the following URL to enable access:\n%s\n", authURL)
+
+	code := codeReceiver.getCode()
+	token, err := conf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		log.Fatal(err)
+	}
+	model := os.Getenv("INFERENCE_MODEL")
+	if model == "" {
+		model = openai.ChatModelGPT4o
+	}
+	log.Printf("Using model %s", model)
+	client := openai.NewClient()
+	params := responses.ResponseNewParams{
+		Model:           model,
+		Tools:           []responses.ToolUnionParam{
+			{
+				OfMcp: &responses.ToolMcpParam{
+					ServerLabel: "google docs",
+					ServerURL:   "http://localhost:9876/mcp",
+					Headers:     map[string]string{
+						"Authorization": "Bearer " + token.AccessToken,
+					},
+					AllowedTools: responses.ToolMcpAllowedToolsUnionParam{
+						OfMcpAllowedTools: []string{
+							"create_doc",
+						},
+					},
+				},
+			},
+		},
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Using the tool provided, create a document containing a poem and return the link to it"),
+		},
+	}
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	log.Println(resp.OutputText())
+	
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Google Workspace MCP example demonstrating OAuth 2.0 PKCE, local auth callback, and using an MCP tool to create a Google Doc from a prompt; supports configurable inference model.

- **Documentation**
  - New README with setup, required environment variables (Google OAuth and OpenAI), run instructions, and MCP server start command.

- **Chores**
  - Added Go module manifest and dependencies for the example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->