### PR TITLE
allow mcp server to send messages to all channels by default

### DIFF
--- a/examples/slack-mcp/slack/run-mcp.sh
+++ b/examples/slack-mcp/slack/run-mcp.sh
@@ -16,6 +16,7 @@ podman run -d \
     -e SLACK_MCP_XOXP_TOKEN="${SLACK_MCP_TOKEN}" \
     -e SLACK_MCP_LOG_LEVEL=debug \
     -e SLACK_MCP_HOST=0.0.0.0 \
+    -e SLACK_MCP_ADD_MESSAGE_TOOL=true \
     -p 13080:13080 \
     ghcr.io/korotovsky/slack-mcp-server:latest \
     mcp-server --transport sse


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
sets the `SLACK_MCP_ADD_MESSAGE_TOOL` to true so that the mcp server has the permissions to send messages to channels 
This is required for most use cases where a notifier agent would need to inform users about something via slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
